### PR TITLE
7 basic counter automated builds

### DIFF
--- a/.buildkite/build_and_deploy.yml
+++ b/.buildkite/build_and_deploy.yml
@@ -9,5 +9,6 @@ steps:
           watch:
             - path: "basic_counter/"
               config:
+                group: ":rocket: Basic counter example"
                 label: ":pipeline: Building basic_counter"
                 command: buildkite-agent pipeline upload basic_counter/.buildkite/build_and_deploy.yml

--- a/.buildkite/build_and_deploy.yml
+++ b/.buildkite/build_and_deploy.yml
@@ -1,0 +1,9 @@
+steps:
+  - label: "Triggering pipelines in demo apps"
+    plugins:
+      - chronotc/monorepo-diff#v2.2.0:
+          diff: "git diff --name-only HEAD~1"
+          watch:
+            - path: "basic_counter/"
+              config:
+                command: buildkite-agent pipeline upload basic_counter/.buildkite/build_and_deploy.yml

--- a/.buildkite/build_and_deploy.yml
+++ b/.buildkite/build_and_deploy.yml
@@ -1,3 +1,6 @@
+env:
+  DOCKER_REPO: europe-docker.pkg.dev/vaxine/vaxineio-examples
+
 steps:
   - label: ":railway_track: Choosing child pipelines"
     plugins:

--- a/.buildkite/build_and_deploy.yml
+++ b/.buildkite/build_and_deploy.yml
@@ -1,9 +1,10 @@
 steps:
-  - label: "Triggering pipelines in demo apps"
+  - label: ":railway_track: Choosing child pipelines"
     plugins:
       - chronotc/monorepo-diff#v2.2.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "basic_counter/"
               config:
+                label: ":pipeline: Building basic_counter"
                 command: buildkite-agent pipeline upload basic_counter/.buildkite/build_and_deploy.yml

--- a/basic_counter/.buildkite/build_and_deploy.yml
+++ b/basic_counter/.buildkite/build_and_deploy.yml
@@ -1,0 +1,4 @@
+steps:
+  - command:
+    - "cd basic_counter && docker build -t europe-docker.pkg.dev/vaxine/vaxineio-examples/basic_counter:latest ."
+    - "docker push europe-docker.pkg.dev/vaxine/vaxineio-examples/basic_counter:latest"

--- a/basic_counter/.buildkite/build_and_deploy.yml
+++ b/basic_counter/.buildkite/build_and_deploy.yml
@@ -5,7 +5,7 @@ env:
 steps:
   - label: ":whale: Build & push the docker container"
     command:
-      - "SHORTSHA=$(echo $BUILDKITE_COMMIT | head -c 7)"
+      - "export SHORTSHA=$(echo $BUILDKITE_COMMIT | head -c 7)"
       - "cd basic_counter && docker build -t $REPO/$IMAGE:latest -t $REPO/$IMAGE:$SHORTSHA ."
       - "docker push $REPO/$IMAGE:$SHORTSHA"
       - "docker push $REPO/$IMAGE:latest"

--- a/basic_counter/.buildkite/build_and_deploy.yml
+++ b/basic_counter/.buildkite/build_and_deploy.yml
@@ -6,6 +6,6 @@ steps:
   - label: ":whale: Build & push the docker container"
     command:
       - "export SHORTSHA=$(echo $BUILDKITE_COMMIT | head -c 7)"
-      - "cd basic_counter && docker build -t $REPO/$IMAGE:latest -t $REPO/$IMAGE:$SHORTSHA ."
+      - "cd basic_counter && docker build -t $REPO/$IMAGE:latest -t $REPO/$IMAGE:$$SHORTSHA ."
       - "docker push $REPO/$IMAGE:$SHORTSHA"
       - "docker push $REPO/$IMAGE:latest"

--- a/basic_counter/.buildkite/build_and_deploy.yml
+++ b/basic_counter/.buildkite/build_and_deploy.yml
@@ -1,4 +1,11 @@
+env:
+  REPO: europe-docker.pkg.dev/vaxine/vaxineio-examples
+  IMAGE: basic_counter
+
 steps:
-  - command:
-    - "cd basic_counter && docker build -t europe-docker.pkg.dev/vaxine/vaxineio-examples/basic_counter:latest ."
-    - "docker push europe-docker.pkg.dev/vaxine/vaxineio-examples/basic_counter:latest"
+  - label: ":whale: Build & push the docker container"
+    command:
+      - "SHORTSHA=$(echo $BUILDKITE_COMMIT | head -c 7)"
+      - "cd basic_counter && docker build -t $REPO/$IMAGE:latest -t $REPO/$IMAGE:$SHORTSHA ."
+      - "docker push $REPO/$IMAGE:$SHORTSHA"
+      - "docker push $REPO/$IMAGE:latest"

--- a/basic_counter/.buildkite/build_and_deploy.yml
+++ b/basic_counter/.buildkite/build_and_deploy.yml
@@ -7,5 +7,5 @@ steps:
     command:
       - "export SHORTSHA=$(echo $BUILDKITE_COMMIT | head -c 7)"
       - "cd basic_counter && docker build -t $REPO/$IMAGE:latest -t $REPO/$IMAGE:$$SHORTSHA ."
-      - "docker push $REPO/$IMAGE:$SHORTSHA"
+      - "docker push $REPO/$IMAGE:$$SHORTSHA"
       - "docker push $REPO/$IMAGE:latest"

--- a/basic_counter/.buildkite/build_and_deploy.yml
+++ b/basic_counter/.buildkite/build_and_deploy.yml
@@ -1,11 +1,10 @@
 env:
-  REPO: europe-docker.pkg.dev/vaxine/vaxineio-examples
-  IMAGE: basic_counter
+  IMAGE_NAME: basic_counter
 
 steps:
   - label: ":whale: Build & push the docker container"
     command:
-      - "export SHORTSHA=$(echo $BUILDKITE_COMMIT | head -c 7)"
-      - "cd basic_counter && docker build -t $REPO/$IMAGE:latest -t $REPO/$IMAGE:$$SHORTSHA ."
-      - "docker push $REPO/$IMAGE:$$SHORTSHA"
-      - "docker push $REPO/$IMAGE:latest"
+      - "SHORTSHA=$(echo $BUILDKITE_COMMIT | head -c 7)"
+      - "cd basic_counter && docker build -t ${DOCKER_REPO?}/${IMAGE_NAME?}:latest -t ${DOCKER_REPO?}/${IMAGE_NAME?}:$$SHORTSHA ."
+      - "docker push ${DOCKER_REPO?}/${IMAGE_NAME?}:$$SHORTSHA"
+      - "docker push ${DOCKER_REPO?}/${IMAGE_NAME?}:latest"

--- a/basic_counter/.dockerignore
+++ b/basic_counter/.dockerignore
@@ -24,6 +24,9 @@
 !.git/HEAD
 !.git/refs
 
+# Infrastructure files
+.buildkite/
+
 # Common development/test artifacts
 /cover/
 /doc/


### PR DESCRIPTION
Closes #7 

Includes:
- Basic build pipeline setup
- Assumes builds only from `main` - that's configured in BuildKite website
- No caching since the build agent I've set up will act as a docker build cache

Deployment to google cloud run will be in the next PR